### PR TITLE
Replace Ctx datatype by Ctx type family to allow for empty contexts

### DIFF
--- a/src-array/ValueLifted.hs
+++ b/src-array/ValueLifted.hs
@@ -1,66 +1,61 @@
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
--- The simplifiable class constraints warning is suppressed because
--- these redundant Always constraints are needed to make backpack 
--- see that type signatures match up.
-{-# OPTIONS_GHC -O2 -fno-warn-simplifiable-class-constraints #-}
+{-# OPTIONS_GHC -O2 #-}
 
 module ValueLifted where
 
 import Prelude hiding (map)
 
 import Control.Monad.ST (ST)
+import Data.Kind
 import Data.Primitive.Types
 import Data.Primitive.Array
 import qualified Data.Foldable as F
 
-class Always a where
-
-instance Always a
-
 type MArr = MutableArray
 type Arr = Array
-type Ctx = Always
+type family Ctx a :: Constraint where
+  Ctx a = ()
 
 errorThunk :: a
 errorThunk = error "primitive-containers: ValueLifted: uninitialized element"
 {-# NOINLINE errorThunk #-}
 
-new :: Always a => Int -> ST s (MutableArray s a)
+new :: Ctx a => Int -> ST s (MutableArray s a)
 new n = newArray n errorThunk
 
-index :: Always a => Array a -> Int -> a
+index :: Ctx a => Array a -> Int -> a
 index = indexArray
 
-read :: Always a => MutableArray s a -> Int -> ST s a
+read :: Ctx a => MutableArray s a -> Int -> ST s a
 read = readArray
 
-write :: Always a => MutableArray s a -> Int -> a -> ST s ()
+write :: Ctx a => MutableArray s a -> Int -> a -> ST s ()
 write = writeArray
 
-resize :: Always a => MutableArray s a -> Int -> ST s (MutableArray s a)
+resize :: Ctx a => MutableArray s a -> Int -> ST s (MutableArray s a)
 resize !src !sz = do
   dst <- newArray sz errorThunk
   copyMutableArray dst 0 src 0 (min sz (sizeofMutableArray src))
   return dst
 
-cloneMut :: Always a => MutableArray s a -> Int -> Int -> ST s (MutableArray s a)
+cloneMut :: MutableArray s a -> Int -> Int -> ST s (MutableArray s a)
 cloneMut = cloneMutableArray
 
-copy :: Always a => MutableArray s a -> Int -> Array a -> Int -> Int -> ST s ()
+copy :: Ctx a => MutableArray s a -> Int -> Array a -> Int -> Int -> ST s ()
 copy = copyArray
 
 unsafeFreeze :: MutableArray s a -> ST s (Array a)
 unsafeFreeze = unsafeFreezeArray
 
-size :: Always a => Array a -> Int
+size :: Ctx a => Array a -> Int
 size = sizeofArray
 
-foldr :: Always a => (a -> b -> b) -> b -> Array a -> b
+foldr ::Ctx a => (a -> b -> b) -> b -> Array a -> b
 foldr = F.foldr
 
-map :: (Always a, Always b) => (a -> b) -> Array a -> Array b
+map :: (Ctx a, Ctx b) => (a -> b) -> Array a -> Array b
 map = fmap
 

--- a/src-array/ValueUnboxed.hs
+++ b/src-array/ValueUnboxed.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -O2 #-}
 
@@ -10,35 +11,36 @@ import Data.Primitive.PrimArray
 
 type MArr = MutablePrimArray
 type Arr = PrimArray
-type Ctx = Prim
+type family Ctx a where
+  Ctx a = Prim a
 
-new :: Prim a => Int -> ST s (MutablePrimArray s a)
+new :: Ctx a => Int -> ST s (MutablePrimArray s a)
 new = newPrimArray
 
-index :: Prim a => PrimArray a -> Int -> a
+index :: Ctx a => PrimArray a -> Int -> a
 index = indexPrimArray
 
-read :: Prim a => MutablePrimArray s a -> Int -> ST s a
+read :: Ctx a => MutablePrimArray s a -> Int -> ST s a
 read = readPrimArray
 
-write :: Prim a => MutablePrimArray s a -> Int -> a -> ST s ()
+write :: Ctx a => MutablePrimArray s a -> Int -> a -> ST s ()
 write = writePrimArray
 
-resize :: Prim a => MutablePrimArray s a -> Int -> ST s (MutablePrimArray s a)
+resize :: Ctx a => MutablePrimArray s a -> Int -> ST s (MutablePrimArray s a)
 resize = resizeMutablePrimArray
 
-copy :: Prim a => MutablePrimArray s a -> Int -> PrimArray a -> Int -> Int -> ST s ()
+copy :: Ctx a => MutablePrimArray s a -> Int -> PrimArray a -> Int -> Int -> ST s ()
 copy = copyPrimArray
 
 unsafeFreeze :: MutablePrimArray s a -> ST s (PrimArray a)
 unsafeFreeze = unsafeFreezePrimArray
 
-size :: Prim a => PrimArray a -> Int
+size :: Ctx a => PrimArray a -> Int
 size = sizeofPrimArray
 
-foldr :: Prim a => (a -> b -> b) -> b -> PrimArray a -> b
+foldr :: Ctx a => (a -> b -> b) -> b -> PrimArray a -> b
 foldr = foldrPrimArray
 
-map :: (Prim a, Prim b) => (a -> b) -> PrimArray a -> PrimArray b
+map :: (Ctx a, Ctx b) => (a -> b) -> PrimArray a -> PrimArray b
 map = mapPrimArray
 

--- a/src-array/ValueUnlifted.hs
+++ b/src-array/ValueUnlifted.hs
@@ -1,59 +1,59 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
 
--- The simplifiable class constraints warning is suppressed because
--- these redundant Always constraints are needed to make backpack 
--- see that type signatures match up.
-{-# OPTIONS_GHC -O2 -fno-warn-simplifiable-class-constraints #-}
+{-# OPTIONS_GHC -O2 #-}
 
 module ValueUnlifted where
 
 import Prelude hiding (map)
 
 import Control.Monad.ST (ST)
+import Data.Kind (Constraint)
 import Data.Primitive.Types
 import Data.Primitive.UnliftedArray
 import qualified Data.Foldable as F
 
 type MArr = MutableUnliftedArray
 type Arr = UnliftedArray
-type Ctx = PrimUnlifted
+type family Ctx a :: Constraint where
+  Ctx a = PrimUnlifted a
 
-new :: PrimUnlifted a => Int -> ST s (MutableUnliftedArray s a)
+new :: Ctx a => Int -> ST s (MutableUnliftedArray s a)
 new n = unsafeNewUnliftedArray n
 
-index :: PrimUnlifted a => UnliftedArray a -> Int -> a
+index :: Ctx a => UnliftedArray a -> Int -> a
 index = indexUnliftedArray
 
-read :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> ST s a
+read :: Ctx a => MutableUnliftedArray s a -> Int -> ST s a
 read = readUnliftedArray
 
-write :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> a -> ST s ()
+write :: Ctx a => MutableUnliftedArray s a -> Int -> a -> ST s ()
 write = writeUnliftedArray
 
-resize :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> ST s (MutableUnliftedArray s a)
+resize :: Ctx a => MutableUnliftedArray s a -> Int -> ST s (MutableUnliftedArray s a)
 resize !src !sz = do
   dst <- unsafeNewUnliftedArray sz
   copyMutableUnliftedArray dst 0 src 0 (min sz (sizeofMutableUnliftedArray src))
   return dst
 
-cloneMut :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> Int -> ST s (MutableUnliftedArray s a)
+cloneMut :: Ctx a => MutableUnliftedArray s a -> Int -> Int -> ST s (MutableUnliftedArray s a)
 cloneMut = cloneMutableUnliftedArray
 
-copy :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> UnliftedArray a -> Int -> Int -> ST s ()
+copy :: Ctx a => MutableUnliftedArray s a -> Int -> UnliftedArray a -> Int -> Int -> ST s ()
 copy = copyUnliftedArray
 
 unsafeFreeze :: MutableUnliftedArray s a -> ST s (UnliftedArray a)
 unsafeFreeze = unsafeFreezeUnliftedArray
 
-size :: PrimUnlifted a => UnliftedArray a -> Int
+size :: Ctx a => UnliftedArray a -> Int
 size = sizeofUnliftedArray
 
-foldr :: PrimUnlifted a => (a -> b -> b) -> b -> UnliftedArray a -> b
+foldr :: Ctx a => (a -> b -> b) -> b -> UnliftedArray a -> b
 foldr = foldrUnliftedArray
 
-map :: (PrimUnlifted a, PrimUnlifted b) => (a -> b) -> UnliftedArray a -> UnliftedArray b
+map :: (Ctx a, Ctx b) => (a -> b) -> UnliftedArray a -> UnliftedArray b
 map = mapUnliftedArray
 
 

--- a/src-map-indef/Key.hsig
+++ b/src-map-indef/Key.hsig
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 signature Key where
@@ -8,7 +9,7 @@ import Control.Monad.ST (ST)
 
 data Arr :: * -> *
 data MArr :: * -> * -> *
-data Ctx :: * -> Constraint
+type family Ctx a :: Constraint where ..
 
 instance (Ctx a, Eq a) => Eq (Arr a)
 

--- a/src-map-indef/Value.hsig
+++ b/src-map-indef/Value.hsig
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 signature Value where
@@ -8,7 +9,7 @@ import Control.Monad.ST (ST)
 
 data Arr :: * -> *
 data MArr :: * -> * -> *
-data Ctx :: * -> Constraint
+type family Ctx a :: Constraint where ..
 
 instance (Ctx a, Eq a) => Eq (Arr a)
 

--- a/src-set-indef/Value.hsig
+++ b/src-set-indef/Value.hsig
@@ -1,4 +1,5 @@
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 signature Value where
@@ -9,7 +10,7 @@ import Control.Monad.ST (ST)
 
 data Arr :: * -> *
 data MArr :: * -> * -> *
-data Ctx :: * -> Constraint
+type family Ctx a :: Constraint where ..
 
 instance (Ctx a, Eq a) => Eq (Arr a)
 instance PrimUnlifted (Arr a) 


### PR DESCRIPTION
This is the result of me being curious if there was a way to get rid of `Always`. Turns out there is by switching to a type family instead. The advantage apart from getting rid of `Always` is that you could also use multiple constraints in this case by mapping to something like `Ctx a = (Eq a, Ord a)`. The downside is that apparently signatures are checked before type families are expanded so the constraints need to mention `Ctx` explicitely rather than the constraint it maps to (so we can’t omit constraints syntactically in the empty constraints case after all).

As I mentioned this was just an experiment, so definitely feel free to reject it. I just thought it might be interesting and perhaps useful information for someone given that there aren’t too many backpack projects out there in the wild.

Either way, looks like a really cool project! Keep up the good work!