### PR TITLE
Remove all internal use of backpack

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,0 @@
-module Main where
-
-import Lib
-
-main :: IO ()
-main = someFunc

--- a/primitive-containers.cabal
+++ b/primitive-containers.cabal
@@ -25,27 +25,6 @@ library
   build-depends:
       base >=4.7 && <5
     , primitive
-    , set-indef
-    , map-indef
-    , diet-map-indef
-    , array-unboxed
-  mixins:
-      set-indef (Set as Internal.Set.Unboxed)
-        requires (Value as ValueUnboxed)
-    , set-indef (Set as Internal.Set.Lifted)
-        requires (Value as ValueLifted)
-    , set-indef (Set as Internal.Set.Unlifted)
-        requires (Value as ValueUnlifted)
-    , map-indef (Map as Internal.Map.Unboxed.Unboxed)
-        requires (Value as ValueUnboxed,Key as ValueUnboxed)
-    , map-indef (Map as Internal.Map.Unboxed.Lifted)
-        requires (Value as ValueLifted,Key as ValueUnboxed)
-    , map-indef (Map as Internal.Map.Unboxed.Unlifted)
-        requires (Value as ValueUnlifted,Key as ValueUnboxed)
-    , diet-map-indef (Map as Internal.Diet.Map.Unboxed.Lifted)
-        requires (Value as ValueLifted,Key as ValueUnboxed)
-    , diet-map-indef (Map as Internal.Diet.Map.Lifted.Lifted)
-        requires (Value as ValueLifted,Key as ValueLifted)
   exposed-modules:
     Data.Set.Unboxed
     Data.Set.Lifted
@@ -55,36 +34,11 @@ library
     Data.Map.Unboxed.Unlifted
     Data.Diet.Map.Unboxed.Lifted
     Data.Diet.Map.Lifted.Lifted
-  default-language: Haskell2010
-
-library set-indef
-  build-depends: base, primitive
-  signatures: Value
-  exposed-modules: Set
-  hs-source-dirs: src-set-indef
-  default-language: Haskell2010
-
-library map-indef
-  build-depends: base
-  signatures: Key, Value
-  exposed-modules: Map
-  hs-source-dirs: src-map-indef
-  default-language: Haskell2010
-
-library diet-map-indef
-  build-depends: base
-  signatures: Key, Value
-  exposed-modules: Map
-  hs-source-dirs: src-diet-map-indef
-  default-language: Haskell2010
-
-library array-unboxed
-  build-depends: base, primitive
-  exposed-modules:
-      ValueUnboxed
-    , ValueLifted
-    , ValueUnlifted
-  hs-source-dirs: src-array
+  other-modules:
+    Data.Internal
+    Data.Set.Internal
+    Data.Map.Internal
+    Data.Diet.Map.Internal
   default-language: Haskell2010
 
 test-suite test
@@ -109,6 +63,7 @@ benchmark gauge
     benchmark-gauge
   main-is: Main.hs
   type: exitcode-stdio-1.0
+  ghc-options: -Wall -O2
   build-depends:
       base >= 4.8 && < 4.12
     , primitive

--- a/src/Data/Diet/Map/Internal.hs
+++ b/src/Data/Diet/Map/Internal.hs
@@ -1,0 +1,397 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -O2 -Wall #-}
+module Data.Diet.Map.Internal
+  ( Map
+  , empty
+  , singleton
+  , map
+  , append
+  , lookup
+  , concat
+  , equals
+  , showsPrec
+  , liftShowsPrec2
+    -- list conversion
+  , fromListN
+  , fromList
+  , fromListAppend
+  , fromListAppendN
+  , toList
+  ) where
+
+import Prelude hiding (lookup,showsPrec,concat,map)
+
+import Control.Applicative (liftA2)
+import Control.Monad.ST (ST,runST)
+import Data.Semigroup (Semigroup)
+import Data.Foldable (foldl')
+import Text.Show (showListWith)
+import Data.Internal (Contiguous,Element)
+import qualified Data.List as L
+import qualified Data.Semigroup as SG
+import qualified Prelude as P
+import qualified Data.Internal as I
+
+-- The key array is twice as long as the value array since
+-- everything is stored as a range. Also, figure out how to
+-- unpack these two arguments at some point.
+data Map karr varr k v = Map !(karr k) !(varr v)
+
+empty :: (Contiguous karr, Contiguous varr) => Map karr varr k v
+empty = Map I.empty I.empty
+
+map :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v, Element varr w) => (v -> w) -> Map karr varr k v -> Map karr varr k w
+map f (Map k v) = Map k (I.map f v)
+
+equals :: (Contiguous karr, Element karr k, Eq k, Contiguous varr, Element varr v, Eq v) => Map karr varr k v -> Map karr varr k v -> Bool
+equals (Map k1 v1) (Map k2 v2) = I.equals k1 k2 && I.equals v1 v2
+
+fromListN :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v) => Int -> [(k,k,v)] -> Map karr varr k v
+fromListN = fromListWithN (\_ a -> a)
+
+fromList :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v) => [(k,k,v)] -> Map karr varr k v
+fromList = fromListN 1
+
+fromListAppendN :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Semigroup v, Eq v) => Int -> [(k,k,v)] -> Map karr varr k v
+fromListAppendN = fromListWithN (SG.<>)
+
+fromListAppend :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Semigroup v, Eq v) => [(k,k,v)] -> Map karr varr k v
+fromListAppend = fromListAppendN 1
+
+fromListWithN :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v) => (v -> v -> v) -> Int -> [(k,k,v)] -> Map karr varr k v
+fromListWithN combine _ xs =
+  concatWith combine (P.map (\(lo,hi,v) -> singleton lo hi v) xs)
+
+concat :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Semigroup v, Eq v) => [Map karr varr k v] -> Map karr varr k v
+concat = concatWith (SG.<>)
+
+singleton :: (Contiguous karr, Element karr k,Ord k,Contiguous varr, Element varr v) => k -> k -> v -> Map karr varr k v
+singleton !lo !hi !v = if lo <= hi
+  then Map
+    ( runST $ do
+        arr <- I.new 2
+        I.write arr 0 lo
+        I.write arr 1 hi
+        I.unsafeFreeze arr
+    )
+    ( runST $ do
+        arr <- I.new 1
+        I.write arr 0 v
+        I.unsafeFreeze arr
+    )
+  else empty
+
+lookup :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => k -> Map karr varr k v -> Maybe v
+lookup a (Map keys vals) = go 0 (I.size vals - 1) where
+  go :: Int -> Int -> Maybe v
+  go !start !end = if end <= start
+    then if end == start
+      then 
+        let !valLo = I.index keys (2 * start)
+            !valHi = I.index keys (2 * start + 1)
+         in if a >= valLo && a <= valHi
+              then Just (I.index vals start)
+              else Nothing
+      else Nothing
+    else
+      let !mid = div (end + start + 1) 2
+          !valLo = I.index keys (2 * mid)
+       in case P.compare a valLo of
+            LT -> go start (mid - 1)
+            EQ -> Just (I.index vals mid)
+            GT -> go mid end
+{-# INLINEABLE lookup #-}
+
+
+append :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Semigroup v, Eq v) => Map karr varr k v -> Map karr varr k v -> Map karr varr k v
+append (Map ksA vsA) (Map ksB vsB) =
+  case unionArrWith (SG.<>) ksA vsA ksB vsB of
+    (k,v) -> Map k v
+
+appendWith :: (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v) => (v -> v -> v) -> Map karr varr k v -> Map karr varr k v -> Map karr varr k v
+appendWith combine (Map ksA vsA) (Map ksB vsB) =
+  case unionArrWith combine ksA vsA ksB vsB of
+    (k,v) -> Map k v
+  
+  
+unionArrWith :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v)
+  => (v -> v -> v)
+  -> karr k -- keys a
+  -> varr v -- values a
+  -> karr k -- keys b
+  -> varr v -- values b
+  -> (karr k, varr v)
+unionArrWith combine keysA valsA keysB valsB
+  | I.size valsA < 1 = (keysB,valsB)
+  | I.size valsB < 1 = (keysA,valsA)
+  | otherwise = runST action
+  where
+  action :: forall s. ST s (karr k, varr v)
+  action = do
+    let !szA = I.size valsA
+        !szB = I.size valsB
+    !keysDst <- I.new (max szA szB * 8)
+    !valsDst <- I.new (max szA szB * 4)
+    let writeKeyRange :: Int -> k -> k -> ST s ()
+        writeKeyRange !ix !lo !hi = do
+          I.write keysDst (2 * ix) lo
+          I.write keysDst (2 * ix + 1) hi
+        writeDstHiKey :: Int -> k -> ST s ()
+        writeDstHiKey !ix !hi = I.write keysDst (2 * ix + 1) hi
+        writeDstValue :: Int -> v -> ST s ()
+        writeDstValue !ix !v = I.write valsDst ix v
+        readDstHiKey :: Int -> ST s k
+        readDstHiKey !ix = I.read keysDst (2 * ix + 1)
+        readDstVal :: Int -> ST s v
+        readDstVal !ix = I.read valsDst ix
+        indexLoKeyA :: Int -> k
+        indexLoKeyA !ix = I.index keysA (ix * 2)
+        indexLoKeyB :: Int -> k
+        indexLoKeyB !ix = I.index keysB (ix * 2)
+        indexHiKeyA :: Int -> k
+        indexHiKeyA !ix = I.index keysA (ix * 2 + 1)
+        indexHiKeyB :: Int -> k
+        indexHiKeyB !ix = I.index keysB (ix * 2 + 1)
+        indexValueA :: Int -> v
+        indexValueA !ix = I.index valsA ix
+        indexValueB :: Int -> v
+        indexValueB !ix = I.index valsB ix
+    -- In the go functon, ixDst is always at least one. Similarly,
+    -- all key arguments are always greater than minBound.
+    let go :: Int -> k -> k -> v -> Int -> k -> k -> v -> Int -> ST s Int
+        go !ixA !loA !hiA !valA !ixB !loB !hiB !valB !ixDst = do
+          prevHi <- readDstHiKey (ixDst - 1) 
+          prevVal <- readDstVal (ixDst - 1) 
+          case compare loA loB of
+            LT -> do
+              let (upper,ixA') = if hiA < loB
+                    then (hiA,ixA + 1)
+                    else (pred loB,ixA)
+              ixDst' <- if pred loA == prevHi && valA == prevVal
+                then do
+                  writeDstHiKey (ixDst - 1) upper
+                  return ixDst
+                else do
+                  writeKeyRange ixDst loA upper
+                  writeDstValue ixDst valA
+                  return (ixDst + 1)
+              if ixA' < szA
+                then do
+                  let (loA',hiA') = if hiA < loB
+                        then (indexLoKeyA ixA',indexHiKeyA ixA')
+                        else (loB,hiA)
+                  go ixA' loA' hiA' (indexValueA ixA') ixB loB hiB valB ixDst'
+                else copyB ixB loB hiB valB ixDst'
+            GT -> do
+              let (upper,ixB') = if hiB < loA
+                    then (hiB,ixB + 1)
+                    else (pred loA,ixB)
+              ixDst' <- if pred loB == prevHi && valB == prevVal
+                then do
+                  writeDstHiKey (ixDst - 1) upper
+                  return ixDst
+                else do
+                  writeKeyRange ixDst loB upper
+                  writeDstValue ixDst valB
+                  return (ixDst + 1)
+              if ixB' < szB
+                then do
+                  let (loB',hiB') = if hiB < loA
+                        then (indexLoKeyB ixB',indexHiKeyB ixB')
+                        else (loA,hiB)
+                  go ixA loA hiA valA ixB' loB' hiB' (indexValueB ixB') ixDst'
+                else copyA ixA loA hiA valA ixDst'
+            EQ -> do
+              let valCombination = combine valA valB
+              case compare hiA hiB of
+                LT -> do
+                  ixDst' <- if pred loA == prevHi && valCombination == prevVal
+                    then do
+                      writeDstHiKey (ixDst - 1) hiA
+                      return ixDst
+                    else do
+                      writeKeyRange ixDst loA hiA
+                      writeDstValue ixDst valCombination
+                      return (ixDst + 1)
+                  let ixA' = ixA + 1
+                      loB' = succ hiA
+                  if ixA' < szA
+                    then go ixA' (indexLoKeyA ixA') (indexHiKeyA ixA') (indexValueA ixA') ixB loB' hiB valB ixDst'
+                    else copyB ixB loB' hiB valB ixDst'
+                GT -> do
+                  ixDst' <- if pred loB == prevHi && valCombination == prevVal
+                    then do
+                      writeDstHiKey (ixDst - 1) hiB
+                      return ixDst
+                    else do
+                      writeKeyRange ixDst loB hiB
+                      writeDstValue ixDst valCombination
+                      return (ixDst + 1)
+                  let ixB' = ixB + 1
+                      loA' = succ hiB
+                  if ixB' < szB
+                    then go ixA loA' hiA valA ixB' (indexLoKeyB ixB') (indexHiKeyB ixB') (indexValueB ixB') ixDst'
+                    else copyA ixA loA' hiA valA ixDst'
+                EQ -> do
+                  ixDst' <- if pred loB == prevHi && valCombination == prevVal
+                    then do
+                      writeDstHiKey (ixDst - 1) hiB
+                      return ixDst
+                    else do
+                      writeKeyRange ixDst loB hiB
+                      writeDstValue ixDst valCombination
+                      return (ixDst + 1)
+                  let ixA' = ixA + 1
+                      ixB' = ixB + 1
+                  if ixA' < szA
+                    then if ixB' < szB
+                      then go ixA' (indexLoKeyA ixA') (indexHiKeyA ixA') (indexValueA ixA') ixB' (indexLoKeyB ixB') (indexHiKeyB ixB') (indexValueB ixB') ixDst'
+                      else copyA ixA' (indexLoKeyA ixA') (indexHiKeyA ixA') (indexValueA ixA') ixDst'
+                    else if ixB' < szB
+                      then copyB ixB' (indexLoKeyB ixB') (indexHiKeyB ixB') (indexValueB ixB') ixDst'
+                      else return ixDst'
+        copyB :: Int -> k -> k -> v -> Int -> ST s Int
+        copyB !ixB !loB !hiB !valB !ixDst = do
+          prevHi <- readDstHiKey (ixDst - 1) 
+          prevVal <- readDstVal (ixDst - 1) 
+          ixDst' <- if pred loB == prevHi && valB == prevVal
+            then do
+              writeDstHiKey (ixDst - 1) hiB
+              return ixDst
+            else do
+              writeKeyRange ixDst loB hiB
+              writeDstValue ixDst valB
+              return (ixDst + 1)
+          let ixB' = ixB + 1
+              remaining = szB - ixB'
+          I.copy keysDst (ixDst' * 2) keysB (ixB' * 2) (remaining * 2)
+          I.copy valsDst ixDst' valsB ixB' remaining
+          return (ixDst' + remaining)
+        copyA :: Int -> k -> k -> v -> Int -> ST s Int
+        copyA !ixA !loA !hiA !valA !ixDst = do
+          prevHi <- readDstHiKey (ixDst - 1) 
+          prevVal <- readDstVal (ixDst - 1) 
+          ixDst' <- if pred loA == prevHi && valA == prevVal
+            then do
+              writeDstHiKey (ixDst - 1) hiA
+              return ixDst
+            else do
+              writeKeyRange ixDst loA hiA
+              writeDstValue ixDst valA
+              return (ixDst + 1)
+          let ixA' = ixA + 1
+              remaining = szA - ixA'
+          I.copy keysDst (ixDst' * 2) keysA (ixA' * 2) (remaining * 2)
+          I.copy valsDst ixDst' valsA ixA' remaining
+          return (ixDst' + remaining)
+    let !loA0 = indexLoKeyA 0
+        !loB0 = indexLoKeyB 0
+        !hiA0 = indexHiKeyA 0
+        !hiB0 = indexHiKeyB 0
+        !valA0 = indexValueA 0
+        !valB0 = indexValueB 0
+    total <- case compare loA0 loB0 of
+      LT -> if hiA0 < loB0
+        then do
+          writeKeyRange 0 loA0 hiA0
+          writeDstValue 0 valA0
+          if 1 < szA
+            then go 1 (indexLoKeyA 1) (indexHiKeyA 1) (indexValueA 1) 0 loB0 hiB0 valB0 1
+            else copyB 0 loB0 hiB0 valB0 1
+        else do
+          -- here we know that hiA > loA
+          let !upperA = pred loB0
+          writeKeyRange 0 loA0 upperA
+          writeDstValue 0 valA0
+          go 0 loB0 hiA0 valA0 0 loB0 hiB0 valB0 1
+      EQ -> case compare hiA0 hiB0 of
+        LT -> do
+          writeKeyRange 0 loA0 hiA0
+          writeDstValue 0 (combine valA0 valB0)
+          if 1 < szA
+            then go 1 (indexLoKeyA 1) (indexHiKeyA 1) (indexValueA 1) 0 (succ hiA0) hiB0 valB0 1
+            else copyB 0 (succ hiA0) hiB0 valB0 1
+        GT -> do
+          writeKeyRange 0 loB0 hiB0
+          writeDstValue 0 (combine valA0 valB0)
+          if 1 < szB
+            then go 0 (succ hiB0) hiA0 valA0 1 (indexLoKeyB 1) (indexHiKeyB 1) (indexValueB 1) 1
+            else copyA 0 (succ hiB0) hiA0 valA0 1
+        EQ -> do
+          writeKeyRange 0 loA0 hiA0
+          writeDstValue 0 (combine valA0 valB0)
+          if 1 < szA
+            then if 1 < szB
+              then go 1 (indexLoKeyA 1) (indexHiKeyA 1) (indexValueA 1) 1 (indexLoKeyB 1) (indexHiKeyB 1) (indexValueB 1) 1
+              else copyA 1 (indexLoKeyA 1) (indexHiKeyA 1) (indexValueA 1) 1
+            else if 1 < szB
+              then copyB 1 (indexLoKeyB 1) (indexHiKeyB 1) (indexValueB 1) 1
+              else return 1
+      GT -> if hiB0 < loA0
+        then do
+          writeKeyRange 0 loB0 hiB0
+          writeDstValue 0 valB0
+          if 1 < szB
+            then go 0 loA0 hiA0 valA0 1 (indexLoKeyB 1) (indexHiKeyB 1) (indexValueB 1) 1
+            else copyA 0 loA0 hiA0 valA0 1
+        else do
+          let !upperB = pred loA0
+          writeKeyRange 0 loB0 upperB
+          writeDstValue 0 valB0
+          go 0 loA0 hiA0 valA0 0 loA0 hiB0 valB0 1
+    !keysFinal <- I.resize keysDst (total * 2)
+    !valsFinal <- I.resize valsDst total
+    liftA2 (,) (I.unsafeFreeze keysFinal) (I.unsafeFreeze valsFinal)
+
+concatWith :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Enum k, Contiguous varr, Element varr v, Eq v) => (v -> v -> v) -> [Map karr varr k v] -> Map karr varr k v
+concatWith combine = go [] where
+  go :: [Map karr varr k v] -> [Map karr varr k v] -> Map karr varr k v
+  go !stack [] = foldl' (appendWith combine) empty (L.reverse stack)
+  go !stack (x : xs) = if size x > 0
+    then go (pushStack x stack) xs
+    else go stack xs
+  pushStack :: Map karr varr k v -> [Map karr varr k v] -> [Map karr varr k v]
+  pushStack x [] = [x]
+  pushStack x (s : ss) = if size x >= size s
+    then pushStack (appendWith combine s x) ss
+    else x : s : ss
+
+size :: (Contiguous varr, Element varr v) => Map karr varr k v -> Int
+size (Map _ vals) = I.size vals 
+
+toList :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => Map karr varr k v -> [(k,k,v)]
+toList = foldrWithKey (\lo hi v xs -> (lo,hi,v) : xs) []
+
+foldrWithKey :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => (k -> k -> v -> b -> b) -> b -> Map karr varr k v -> b
+foldrWithKey f z (Map keys vals) =
+  let !sz = I.size vals
+      go !i
+        | i == sz = z
+        | otherwise =
+            let !lo = I.index keys (i * 2)
+                !hi = I.index keys (i * 2 + 1)
+                !v = I.index vals i
+             in f lo hi v (go (i + 1))
+   in go 0
+
+showsPrec :: (Contiguous karr, Element karr k, Show k, Contiguous varr, Element varr v, Show v) => Int -> Map karr varr k v -> ShowS
+showsPrec p xs = showParen (p > 10) $
+  showString "fromList " . shows (toList xs)
+
+liftShowsPrec2 :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => (Int -> k -> ShowS) -> ([k] -> ShowS) -> (Int -> v -> ShowS) -> ([v] -> ShowS) -> Int -> Map karr varr k v -> ShowS
+liftShowsPrec2 showsPrecK _ showsPrecV _ p xs = showParen (p > 10) $
+  showString "fromList " . showListWith (\(a,b,c) -> show_tuple [showsPrecK 0 a, showsPrecK 0 b, showsPrecV 0 c])  (toList xs)
+
+-- implementation copied from GHC.Show
+show_tuple :: [ShowS] -> ShowS
+show_tuple ss = id
+  . showChar '('
+  . foldr1 (\s r -> s . showChar ',' . r) ss
+  . showChar ')'
+
+

--- a/src/Data/Diet/Map/Lifted/Lifted.hs
+++ b/src/Data/Diet/Map/Lifted/Lifted.hs
@@ -19,11 +19,12 @@ import Prelude hiding (lookup,map)
 
 import Data.Semigroup (Semigroup)
 import Data.Functor.Classes (Show2(..))
+import Data.Primitive (Array)
 import qualified GHC.Exts as E
 import qualified Data.Semigroup as SG
-import qualified Internal.Diet.Map.Lifted.Lifted as I
+import qualified Data.Diet.Map.Internal as I
 
-newtype Map k v = Map (I.Map k v)
+newtype Map k v = Map (I.Map Array Array k v)
 
 -- | /O(1)/ Create a diet map with a single element.
 singleton :: Ord k

--- a/src/Data/Diet/Map/Unboxed/Lifted.hs
+++ b/src/Data/Diet/Map/Unboxed/Lifted.hs
@@ -20,11 +20,13 @@ import Prelude hiding (lookup,map)
 import Data.Semigroup (Semigroup)
 import Data.Primitive.Types (Prim)
 import Data.Functor.Classes (Show2(..))
+import Data.Primitive.PrimArray (PrimArray)
+import Data.Primitive.Array (Array)
 import qualified GHC.Exts as E
 import qualified Data.Semigroup as SG
-import qualified Internal.Diet.Map.Unboxed.Lifted as I
+import qualified Data.Diet.Map.Internal as I
 
-newtype Map k v = Map (I.Map k v)
+newtype Map k v = Map (I.Map PrimArray Array k v)
 
 -- | /O(1)/ Create a diet map with a single element.
 singleton :: (Prim k,Ord k)

--- a/src/Data/Internal.hs
+++ b/src/Data/Internal.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+
+{-# OPTIONS_GHC -O2 -Wall #-}
+module Data.Internal
+  ( Contiguous(..)
+  ) where
+
+import Prelude
+import Control.Monad.ST (ST,runST)
+import Data.Kind (Type)
+import Data.Primitive
+import GHC.Exts (ArrayArray#,Constraint)
+import qualified Prelude as P
+
+class Always a
+
+instance Always a
+
+class Contiguous (arr :: Type -> Type) where
+  type family Mutable arr = (r :: Type -> Type -> Type) | r -> arr
+  type family Element arr :: Type -> Constraint
+  -- type family Unlifted arr :: (r :: Type -> TYPE 'UnliftedRep)
+  -- type family MutableUnlifted arr :: (r :: Type -> Type -> TYPE 'UnliftedRep)
+  empty :: arr a
+  new :: Element arr b => Int -> ST s (Mutable arr s b)
+  index :: Element arr b => arr b -> Int -> b
+  read :: Element arr b => Mutable arr s b -> Int -> ST s b
+  write :: Element arr b => Mutable arr s b -> Int -> b -> ST s ()
+  resize :: Element arr b => Mutable arr s b -> Int -> ST s (Mutable arr s b)
+  size :: Element arr b => arr b -> Int
+  unsafeFreeze :: Mutable arr s b -> ST s (arr b)
+  copy :: Element arr b => Mutable arr s b -> Int -> arr b -> Int -> Int -> ST s ()
+  foldr :: Element arr b => (b -> c -> c) -> c -> arr b -> c
+  equals :: (Element arr b, Eq b) => arr b -> arr b -> Bool
+  unlift :: arr b -> ArrayArray#
+  lift :: ArrayArray# -> arr b
+  map :: (Element arr b, Element arr c) => (b -> c) -> arr b -> arr c
+
+instance Contiguous PrimArray where
+  type Mutable PrimArray = MutablePrimArray
+  type Element PrimArray = Prim
+  empty = mempty
+  new = newPrimArray
+  index = indexPrimArray
+  read = readPrimArray
+  write = writePrimArray
+  resize = resizeMutablePrimArray
+  size = sizeofPrimArray
+  unsafeFreeze = unsafeFreezePrimArray
+  copy = copyPrimArray
+  foldr = foldrPrimArray
+  equals = (==)
+  unlift = toArrayArray#
+  lift = fromArrayArray#
+  map = mapPrimArray
+
+instance Contiguous Array where
+  type Mutable Array = MutableArray
+  type Element Array = Always
+  empty = mempty
+  new n = newArray n errorThunk
+  index = indexArray
+  read = readArray
+  write = writeArray
+  resize = resizeArray
+  size = sizeofArray
+  unsafeFreeze = unsafeFreezeArray
+  copy = copyArray
+  foldr = P.foldr
+  equals = (==)
+  unlift = toArrayArray#
+  lift = fromArrayArray#
+  map = fmap
+
+instance Contiguous UnliftedArray where
+  type Mutable UnliftedArray = MutableUnliftedArray
+  type Element UnliftedArray = PrimUnlifted
+  empty = emptyUnliftedArray
+  new = unsafeNewUnliftedArray
+  index = indexUnliftedArray
+  read = readUnliftedArray
+  write = writeUnliftedArray
+  resize = resizeUnliftedArray
+  size = sizeofUnliftedArray
+  unsafeFreeze = unsafeFreezeUnliftedArray
+  copy = copyUnliftedArray
+  foldr = foldrUnliftedArray
+  equals = (==)
+  unlift = toArrayArray#
+  lift = fromArrayArray#
+  map = mapUnliftedArray
+
+errorThunk :: a
+errorThunk = error "Contiguous typeclass: unitialized element"
+
+resizeArray :: Always a => MutableArray s a -> Int -> ST s (MutableArray s a)
+resizeArray !src !sz = do
+  dst <- newArray sz errorThunk
+  copyMutableArray dst 0 src 0 (min sz (sizeofMutableArray src))
+  return dst
+
+resizeUnliftedArray :: PrimUnlifted a => MutableUnliftedArray s a -> Int -> ST s (MutableUnliftedArray s a)
+resizeUnliftedArray !src !sz = do
+  dst <- unsafeNewUnliftedArray sz
+  copyMutableUnliftedArray dst 0 src 0 (min sz (sizeofMutableUnliftedArray src))
+  return dst
+
+emptyUnliftedArray :: UnliftedArray a
+emptyUnliftedArray = runST (unsafeNewUnliftedArray 0 >>= unsafeFreezeUnliftedArray)
+

--- a/src/Data/Map/Internal.hs
+++ b/src/Data/Map/Internal.hs
@@ -1,0 +1,247 @@
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+{-# OPTIONS_GHC -O2 -Wall #-}
+module Data.Map.Internal
+  ( Map
+  , empty
+  , singleton
+  , map
+  , append
+  , lookup
+  , showsPrec
+  , equals
+  , compare
+  , toList
+  , concat
+  , size
+    -- list conversion
+  , fromListN
+  , fromList
+  , fromListAppend
+  , fromListAppendN
+  ) where
+
+import Prelude hiding (compare,showsPrec,lookup,map,concat)
+
+import Control.Applicative (liftA2)
+import Control.Monad.ST (ST,runST)
+import Data.Semigroup (Semigroup)
+import Data.Foldable (foldl')
+import Data.Internal (Contiguous,Mutable,Element)
+import qualified Data.List as L
+import qualified Data.Semigroup as SG
+import qualified Prelude as P
+import qualified Data.Internal as I
+
+-- TODO: Do some sneakiness with UnliftedRep
+data Map karr varr k v = Map !(karr k) !(varr v)
+
+empty :: (Contiguous karr, Contiguous varr) => Map karr varr k v
+empty = Map I.empty I.empty
+
+singleton :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => k -> v -> Map karr varr k v
+singleton k v = Map
+  ( runST $ do
+      arr <- I.new 1
+      I.write arr 0 k
+      I.unsafeFreeze arr
+  )
+  ( runST $ do
+      arr <- I.new 1
+      I.write arr 0 v
+      I.unsafeFreeze arr
+  )
+
+equals :: (Contiguous karr, Element karr k, Eq k, Contiguous varr, Element varr v, Eq v) => Map karr varr k v -> Map karr varr k v -> Bool
+equals (Map k1 v1) (Map k2 v2) = I.equals k1 k2 && I.equals v1 v2
+
+compare :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v, Ord v) => Map karr varr k v -> Map karr varr k v -> Ordering
+compare m1 m2 = P.compare (toList m1) (toList m2)
+
+fromListWithN :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => (v -> v -> v) -> Int -> [(k,v)] -> Map karr varr k v
+fromListWithN combine n xs =
+  case xs of
+    [] -> empty
+    (k,v) : ys ->
+      let (leftovers, result) = fromAscListWith combine (max 1 n) k v ys
+       in concatWith combine (result : P.map (uncurry singleton) leftovers)
+
+fromListN :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => Int -> [(k,v)] -> Map karr varr k v
+fromListN = fromListWithN (\_ a -> a)
+
+fromList :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => [(k,v)] -> Map karr varr k v
+fromList = fromListN 1
+
+fromListAppendN :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v, Semigroup v) => Int -> [(k,v)] -> Map karr varr k v
+fromListAppendN = fromListWithN (SG.<>)
+
+fromListAppend :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v, Semigroup v) => [(k,v)] -> Map karr varr k v
+fromListAppend = fromListAppendN 1
+
+fromAscListWith :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v)
+  => (v -> v -> v)
+  -> Int -- initial size of buffer, must be 1 or higher
+  -> k -- first key
+  -> v -- first value
+  -> [(k,v)] -- elements
+  -> ([(k,v)], Map karr varr k v)
+fromAscListWith combine !n !k0 !v0 xs0 = runST $ do
+  keys0 <- I.new n
+  vals0 <- I.new n
+  I.write keys0 0 k0
+  I.write vals0 0 v0
+  let go :: forall s. Int -> k -> Int -> Mutable karr s k -> Mutable varr s v -> [(k,v)] -> ST s ([(k,v)], Map karr varr k v)
+      go !ix !_ !sz !keys !vals [] = if ix == sz
+        then do
+          arrKeys <- I.unsafeFreeze keys
+          arrVals <- I.unsafeFreeze vals
+          return ([],Map arrKeys arrVals)
+        else do
+          keys' <- I.resize keys ix
+          arrKeys <- I.unsafeFreeze keys'
+          vals' <- I.resize vals ix
+          arrVals <- I.unsafeFreeze vals'
+          return ([],Map arrKeys arrVals)
+      go !ix !old !sz !keys !vals ((k,v) : xs) = if ix < sz
+        then case P.compare k old of
+          GT -> do
+            I.write keys ix k
+            I.write vals ix v
+            go (ix + 1) k sz keys vals xs
+          EQ -> do
+            !oldVal <- I.read vals (ix - 1)
+            let !newVal = combine oldVal v
+            I.write vals (ix - 1) newVal
+            go ix k sz keys vals xs
+          LT -> do
+            keys' <- I.resize keys ix
+            arrKeys <- I.unsafeFreeze keys'
+            vals' <- I.resize vals ix
+            arrVals <- I.unsafeFreeze vals'
+            return ((k,v) : xs,Map arrKeys arrVals)
+        else do
+          let sz' = sz * 2
+          keys' <- I.resize keys sz'
+          vals' <- I.resize vals sz'
+          go ix old sz' keys' vals' ((k,v) : xs)
+  go 1 k0 n keys0 vals0 xs0
+
+
+map :: (Contiguous varr, Element varr v, Element varr w) => (v -> w) -> Map karr varr k v -> Map karr varr k w
+map f (Map k v) = Map k (I.map f v)
+
+showsPrec :: (Contiguous karr, Element karr k, Show k, Contiguous varr, Element varr v, Show v) => Int -> Map karr varr k v -> ShowS
+showsPrec p xs = showParen (p > 10) $
+  showString "fromList " . shows (toList xs)
+
+toList :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => Map karr varr k v -> [(k,v)]
+toList = foldrWithKey (\k v xs -> (k,v) : xs) []
+
+foldrWithKey :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v) => (k -> v -> b -> b) -> b -> Map karr varr k v -> b
+foldrWithKey f z (Map keys vals) =
+  let !sz = I.size vals
+      go !i
+        | i == sz = z
+        | otherwise =
+            let !k = I.index keys i
+                !v = I.index vals i
+             in f k v (go (i + 1))
+   in go 0
+
+concat :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v, Semigroup v) => [Map karr varr k v] -> Map karr varr k v
+concat = concatWith (SG.<>)
+
+concatWith :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => (v -> v -> v) -> [Map karr varr k v] -> Map karr varr k v
+concatWith combine = go [] where
+  go :: [Map karr varr k v] -> [Map karr varr k v] -> Map karr varr k v
+  go !stack [] = foldl' (appendWith combine) empty (L.reverse stack)
+  go !stack (x : xs) = if size x > 0
+    then go (pushStack x stack) xs
+    else go stack xs
+  pushStack :: Map karr varr k v -> [Map karr varr k v] -> [Map karr varr k v]
+  pushStack x [] = [x]
+  pushStack x (s : ss) = if size x >= size s
+    then pushStack (appendWith combine s x) ss
+    else x : s : ss
+
+appendWith :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v, Ord k) => (v -> v -> v) -> Map karr varr k v -> Map karr varr k v -> Map karr varr k v
+appendWith combine (Map ksA vsA) (Map ksB vsB) =
+  case unionArrWith combine ksA vsA ksB vsB of
+    (k,v) -> Map k v
+  
+append :: (Contiguous karr, Element karr k, Contiguous varr, Element varr v, Ord k, Semigroup v) => Map karr varr k v -> Map karr varr k v -> Map karr varr k v
+append (Map ksA vsA) (Map ksB vsB) =
+  case unionArrWith (SG.<>) ksA vsA ksB vsB of
+    (k,v) -> Map k v
+  
+unionArrWith :: (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v)
+  => (v -> v -> v)
+  -> karr k -- keys a
+  -> varr v -- values a
+  -> karr k -- keys b
+  -> varr v -- values b
+  -> (karr k, varr v)
+unionArrWith combine keysA valsA keysB valsB
+  | I.size valsA < 1 = (keysB,valsB)
+  | I.size valsB < 1 = (keysA,valsA)
+  | otherwise = runST $ do
+      let !szA = I.size valsA
+          !szB = I.size valsB
+      !keysDst <- I.new (szA + szB)
+      !valsDst <- I.new (szA + szB)
+      let go !ixA !ixB !ixDst = if ixA < szA
+            then if ixB < szB
+              then do
+                let !keyA = I.index keysA ixA
+                    !keyB = I.index keysB ixB
+                    !valA = I.index valsA ixA
+                    !valB = I.index valsB ixB
+                case P.compare keyA keyB of
+                  EQ -> do
+                    I.write keysDst ixDst keyA
+                    let !r = combine valA valB
+                    I.write valsDst ixDst r
+                    go (ixA + 1) (ixB + 1) (ixDst + 1)
+                  LT -> do
+                    I.write keysDst ixDst keyA
+                    I.write valsDst ixDst valA
+                    go (ixA + 1) ixB (ixDst + 1)
+                  GT -> do
+                    I.write keysDst ixDst keyB
+                    I.write valsDst ixDst valB
+                    go ixA (ixB + 1) (ixDst + 1)
+              else do
+                I.copy keysDst ixDst keysA ixA (szA - ixA)
+                I.copy valsDst ixDst valsA ixA (szA - ixA)
+                return (ixDst + (szA - ixA))
+            else if ixB < szB
+              then do
+                I.copy keysDst ixDst keysB ixB (szB - ixB)
+                I.copy valsDst ixDst valsB ixB (szB - ixB)
+                return (ixDst + (szB - ixB))
+              else return ixDst
+      !total <- go 0 0 0
+      !keysFinal <- I.resize keysDst total
+      !valsFinal <- I.resize valsDst total
+      liftA2 (,) (I.unsafeFreeze keysFinal) (I.unsafeFreeze valsFinal)
+ 
+lookup :: forall karr varr k v. (Contiguous karr, Element karr k, Ord k, Contiguous varr, Element varr v) => k -> Map karr varr k v -> Maybe v
+lookup a (Map arr vals) = go 0 (I.size vals - 1) where
+  go :: Int -> Int -> Maybe v
+  go !start !end = if end < start
+    then Nothing
+    else
+      let !mid = div (end + start) 2
+          !v = I.index arr mid
+       in case P.compare a v of
+            LT -> go start (mid - 1)
+            EQ -> Just (I.index vals mid)
+            GT -> go (mid + 1) end
+{-# INLINEABLE lookup #-}
+
+size :: (Contiguous varr, Element varr v) => Map karr varr k v -> Int
+size (Map _ arr) = I.size arr

--- a/src/Data/Map/Unboxed/Lifted.hs
+++ b/src/Data/Map/Unboxed/Lifted.hs
@@ -20,13 +20,14 @@ import Prelude hiding (lookup)
 
 import Data.Semigroup (Semigroup)
 import Data.Primitive.Types (Prim)
+import Data.Primitive (PrimArray,Array)
 import qualified GHC.Exts as E
 import qualified Data.Semigroup as SG
-import qualified Internal.Map.Unboxed.Lifted as I
+import qualified Data.Map.Internal as I
 
 -- | A map from keys @k@ to values @v@. The key type must have a
 --   'Prim' instance and the value type is unconstrained.
-newtype Map k v = Map (I.Map k v)
+newtype Map k v = Map (I.Map PrimArray Array k v)
 
 instance (Prim k, Ord k, Semigroup v) => Semigroup (Map k v) where
   Map x <> Map y = Map (I.append x y)

--- a/src/Data/Map/Unboxed/UnboxedTwo.hs
+++ b/src/Data/Map/Unboxed/UnboxedTwo.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -O2 #-}
-module Data.Map.Unboxed.Unboxed
+module Data.Map.Unboxed.UnboxedTwo
   ( Map
   , singleton
   , lookup
@@ -97,4 +97,5 @@ fromListAppendN n = Map . I.fromListAppendN n
 -- | /O(1)/ The number of elements in the map.
 size :: Prim v => Map k v -> Int
 size (Map m) = I.size m
+
 

--- a/src/Data/Map/Unboxed/Unlifted.hs
+++ b/src/Data/Map/Unboxed/Unlifted.hs
@@ -21,13 +21,14 @@ import Prelude hiding (lookup)
 import Data.Semigroup (Semigroup)
 import Data.Primitive.Types (Prim)
 import Data.Primitive.UnliftedArray (PrimUnlifted)
+import Data.Primitive (PrimArray,UnliftedArray)
 import qualified GHC.Exts as E
 import qualified Data.Semigroup as SG
-import qualified Internal.Map.Unboxed.Unlifted as I
+import qualified Data.Map.Internal as I
 
 -- | A map from keys @k@ to values @v@. The key type and the value
 --   type must both have 'Prim' instances.
-newtype Map k v = Map (I.Map k v)
+newtype Map k v = Map (I.Map PrimArray UnliftedArray k v)
 
 instance (Prim k, Ord k, PrimUnlifted v, Semigroup v) => Semigroup (Map k v) where
   Map x <> Map y = Map (I.append x y)

--- a/src/Data/Set/Internal.hs
+++ b/src/Data/Set/Internal.hs
@@ -1,0 +1,194 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -O2 -Wall #-}
+module Data.Set.Internal
+  ( Set(..)
+  , empty
+  , singleton
+  , append
+  , member
+  , showsPrec
+  , equals
+  , compare
+  , fromListN
+  , fromList
+  , toList
+  , size
+  , concat
+  ) where
+
+import Prelude hiding (compare,showsPrec,concat)
+import qualified Prelude as P
+
+import Control.Monad.ST (ST,runST)
+import Data.Foldable (foldl')
+import Data.Primitive.UnliftedArray (PrimUnlifted(..))
+import Data.Internal (Contiguous,Mutable,Element)
+import qualified Data.Internal as A
+
+newtype Set arr a = Set (arr a)
+
+instance Contiguous arr => PrimUnlifted (Set arr a) where
+  toArrayArray# (Set a) = A.unlift a
+  fromArrayArray# a = Set (A.lift a)
+
+append :: (Contiguous arr, Element arr a, Ord a) => Set arr a -> Set arr a -> Set arr a
+append (Set x) (Set y) = Set (unionArr x y)
+  
+empty :: Contiguous arr => Set arr a
+empty = Set A.empty
+
+equals :: (Contiguous arr, Element arr a, Eq a) => Set arr a -> Set arr a -> Bool
+equals (Set x) (Set y) = A.equals x y
+
+compare :: (Contiguous arr, Element arr a, Ord a) => Set arr a -> Set arr a -> Ordering
+compare (Set x) (Set y) = compareArr x y
+
+fromListN :: (Contiguous arr, Element arr a, Ord a) => Int -> [a] -> Set arr a
+fromListN n xs = -- fromList xs
+  case xs of
+    [] -> empty
+    y : ys ->
+      let (leftovers, result) = fromAscList (max 1 n) y ys
+       in concat (result : P.map singleton leftovers)
+
+fromList :: (Contiguous arr, Element arr a, Ord a) => [a] -> Set arr a
+fromList = fromListN 1
+
+fromAscList :: forall arr a. (Contiguous arr, Element arr a, Ord a)
+  => Int -- initial size of buffer, must be 1 or higher
+  -> a -- first element
+  -> [a] -- elements
+  -> ([a], Set arr a)
+fromAscList !n x0 xs0 = runST $ do
+  marr0 <- A.new n
+  A.write marr0 0 x0
+  let go :: forall s. Int -> a -> Int -> Mutable arr s a -> [a] -> ST s ([a], Set arr a)
+      go !ix !_ !sz !marr [] = if ix == sz
+        then do
+          arr <- A.unsafeFreeze marr
+          return ([],Set arr)
+        else do
+          marr' <- A.resize marr ix
+          arr <- A.unsafeFreeze marr'
+          return ([],Set arr)
+      go !ix !old !sz !marr (x : xs) = if ix < sz
+        then case P.compare x old of
+          GT -> do
+            A.write marr ix x
+            go (ix + 1) x sz marr xs
+          EQ -> go ix x sz marr xs
+          LT -> do
+            marr' <- A.resize marr ix
+            arr <- A.unsafeFreeze marr'
+            return (x : xs,Set arr)
+        else do
+          let sz' = sz * 2
+          marr' <- A.resize marr sz'
+          go ix old sz' marr' (x : xs)
+  go 1 x0 n marr0 xs0
+
+showsPrec :: (Contiguous arr, Element arr a, Show a) => Int -> Set arr a -> ShowS
+showsPrec p xs = showParen (p > 10) $
+  showString "fromList " . shows (toList xs)
+
+toList :: (Contiguous arr, Element arr a) => Set arr a -> [a]
+toList (Set arr) = A.foldr (:) [] arr
+
+member :: forall arr a. (Contiguous arr, Element arr a, Ord a) => a -> Set arr a -> Bool
+member a (Set arr) = go 0 (A.size arr - 1) where
+  go :: Int -> Int -> Bool
+  go !start !end = if end < start
+    then False
+    else
+      let !mid = div (end + start) 2
+          !v = A.index arr mid
+       in case P.compare a v of
+            LT -> go start (mid - 1)
+            EQ -> True
+            GT -> go (mid + 1) end
+{-# INLINEABLE member #-}
+
+concat :: forall arr a. (Contiguous arr, Element arr a, Ord a) => [Set arr a] -> Set arr a
+concat = go [] where
+  go :: [Set arr a] -> [Set arr a] -> Set arr a
+  go !stack [] = foldl' append empty stack
+  go !stack (x : xs) = if size x > 0
+    then go (pushStack x stack) xs
+    else go stack xs
+  pushStack :: Set arr a -> [Set arr a] -> [Set arr a]
+  pushStack x [] = [x]
+  pushStack x (s : ss) = if size x >= size s
+    then pushStack (append x s) ss
+    else x : s : ss
+
+compareArr :: (Contiguous arr, Element arr a, Ord a)
+  => arr a
+  -> arr a
+  -> Ordering
+compareArr arrA arrB = go 0 where
+  go :: Int -> Ordering
+  go !ix = if ix < A.size arrA
+    then if ix < A.size arrB
+      then mappend (P.compare (A.index arrA ix) (A.index arrB ix)) (go (ix + 1))
+      else GT
+    else if ix < A.size arrB
+      then LT
+      else EQ
+
+singleton :: (Contiguous arr, Element arr a) => a -> Set arr a
+singleton a = Set $ runST $ do
+  arr <- A.new 1
+  A.write arr 0 a
+  A.unsafeFreeze arr
+
+unionArr :: (Contiguous arr, Element arr a, Ord a)
+  => arr a -- array x
+  -> arr a -- array y
+  -> arr a
+unionArr arrA arrB
+  | szA < 1 = arrB
+  | szB < 1 = arrA
+  | otherwise = runST $ do
+      arrDst <- A.new (szA + szB)
+      let go !ixA !ixB !ixDst = if ixA < szA
+            then if ixB < szB
+              then do
+                let !a = A.index arrA ixA
+                    !b = A.index arrB ixB
+                case P.compare a b of
+                  EQ -> do
+                    A.write arrDst ixDst a
+                    go (ixA + 1) (ixB + 1) (ixDst + 1)
+                  LT -> do
+                    A.write arrDst ixDst a
+                    go (ixA + 1) ixB (ixDst + 1)
+                  GT -> do
+                    A.write arrDst ixDst b
+                    go ixA (ixB + 1) (ixDst + 1)
+              else do
+                A.copy arrDst ixDst arrA ixA (szA - ixA)
+                return (ixDst + (szA - ixA))
+            else if ixB < szB
+              then do
+                A.copy arrDst ixDst arrB ixB (szB - ixB)
+                return (ixDst + (szB - ixB))
+              else return ixDst
+      total <- go 0 0 0
+      arrFinal <- A.resize arrDst total
+      A.unsafeFreeze arrFinal
+  where
+  !szA = A.size arrA
+  !szB = A.size arrB
+
+size :: (Contiguous arr, Element arr a) => Set arr a -> Int
+size (Set arr) = A.size arr
+
+
+

--- a/src/Data/Set/Lifted.hs
+++ b/src/Data/Set/Lifted.hs
@@ -13,12 +13,13 @@ module Data.Set.Lifted
 
 import Data.Primitive.UnliftedArray (PrimUnlifted(..))
 import Data.Semigroup (Semigroup)
+import Data.Primitive (Array)
 import qualified Data.Foldable as F
 import qualified Data.Semigroup as SG
 import qualified GHC.Exts as E
-import qualified Internal.Set.Lifted as I
+import qualified Data.Set.Internal as I
 
-newtype Set a = Set (I.Set a)
+newtype Set a = Set (I.Set Array a)
 
 instance PrimUnlifted (Set a) where
   toArrayArray# (Set x) = toArrayArray# x

--- a/src/Data/Set/Unboxed.hs
+++ b/src/Data/Set/Unboxed.hs
@@ -14,14 +14,15 @@ module Data.Set.Unboxed
 
 import Data.Primitive.Types (Prim)
 import Data.Primitive.UnliftedArray (PrimUnlifted(..))
+import Data.Primitive.PrimArray (PrimArray)
 import Data.Semigroup (Semigroup)
 import qualified Data.Foldable as F
 import qualified Data.Semigroup as SG
 import qualified GHC.Exts as E
-import qualified Internal.Set.Unboxed as I
+import qualified Data.Set.Internal as I
 
 -- | A set of elements.
-newtype Set a = Set (I.Set a)
+newtype Set a = Set (I.Set PrimArray a)
 
 instance PrimUnlifted (Set a) where
   toArrayArray# (Set x) = toArrayArray# x
@@ -71,4 +72,5 @@ singleton = Set . I.singleton
 -- | The number of elements in the set.
 size :: Prim a => Set a -> Int
 size (Set s) = I.size s
+
 

--- a/src/Data/Set/Unlifted.hs
+++ b/src/Data/Set/Unlifted.hs
@@ -12,15 +12,15 @@ module Data.Set.Unlifted
   , size
   ) where
 
-import Data.Primitive.UnliftedArray (PrimUnlifted(..))
+import Data.Primitive.UnliftedArray (UnliftedArray, PrimUnlifted(..))
 import Data.Semigroup (Semigroup)
 import qualified Data.Foldable as F
 import qualified Data.Semigroup as SG
 import qualified GHC.Exts as E
-import qualified Internal.Set.Unlifted as I
+import qualified Data.Set.Internal as I
 
 -- | A set of elements.
-newtype Set a = Set (I.Set a)
+newtype Set a = Set (I.Set UnliftedArray a)
 
 instance PrimUnlifted (Set a) where
   toArrayArray# (Set x) = toArrayArray# x


### PR DESCRIPTION
Backpack causes nix and stack to break, and in a weird turn of events, the backpack implementation actually performed *worse* on benchmarks due to different inlining behavior.